### PR TITLE
Bind JavaFX to runtime JDK version

### DIFF
--- a/.idea/runConfigurations/Run_Client.xml
+++ b/.idea/runConfigurations/Run_Client.xml
@@ -50,6 +50,7 @@
           <option name="goals">
             <list>
               <option value="javafx:run" />
+              <option value="-Dconfig.executable=${user.home}/.jdks/temurin-22.0.1/bin/java" />
             </list>
           </option>
           <option name="multimoduleDir" />

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -13,7 +13,9 @@
     <name>client</name>
 
     <properties>
-        <maven.compiler.release>20</maven.compiler.release>
+        <!-- The config.executable variable should match the same Java version used to run this application -->
+        <!-- This might differ depending on if your IDE is using a bundled Java version -->
+        <config.executable>java</config.executable>
     </properties>
 
     <dependencies>
@@ -71,12 +73,14 @@
                                 <option>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000</option>
                             </options>
                             <mainClass>io.github.chitchat.client/io.github.chitchat.client.HelloApplication</mainClass>
+                            <executable>${config.executable}</executable>
                         </configuration>
                     </execution>
                     <execution>
                         <id>default-cli</id>
                         <configuration>
                             <mainClass>io.github.chitchat.client/io.github.chitchat.client.HelloApplication</mainClass>
+                            <executable>${config.executable}</executable>
                             <compress>2</compress>
                             <launcher>chitchat</launcher>
                             <jlinkZipName>chitchat</jlinkZipName>


### PR DESCRIPTION
Makes sure that the `javafx-maven-plugin` always uses the same JDK version that was used at compile time.